### PR TITLE
nullpogaの実装例を追加

### DIFF
--- a/pythonProject/.gitignore
+++ b/pythonProject/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/pythonProject/nullpoga_cui_2/gameutils/card_type.py
+++ b/pythonProject/nullpoga_cui_2/gameutils/card_type.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+import types
+
+
+class CardType(Enum):
+    SPELL = "SPELL"
+    MONSTER = "MONSTER"

--- a/pythonProject/nullpoga_cui_2/gameutils/monster_cards.py
+++ b/pythonProject/nullpoga_cui_2/gameutils/monster_cards.py
@@ -26,6 +26,7 @@ class MonsterCard:
         self.stun_count = 0
         self.can_act = True  # 行動（攻撃）可能か。必要？
         self.attack_declaration = False  # 攻撃宣言済みか
+        self.done_activity = False # 行動済みかどうか
 
     def __str__(self):
         return f"{self.card_name}"

--- a/pythonProject/nullpoga_cui_2/gameutils/monster_cards.py
+++ b/pythonProject/nullpoga_cui_2/gameutils/monster_cards.py
@@ -1,0 +1,81 @@
+from typing import List
+from .card_type import CardType
+import uuid
+from uuid import UUID
+
+
+class MonsterCard:
+    activity_done_f: bool
+    stun_count: int
+    life: int
+    attack: int
+    card_name: str
+    mana_cost: int
+    card_type: CardType
+    card_no: int
+    uniq_id: UUID
+
+    def __init__(self, card_no: int, mana_cost: int, card_name: str, attack: int, life: int):
+        self.uniq_id = uuid.uuid4()
+        self.card_no = card_no
+        self.card_type = CardType.MONSTER
+        self.mana_cost = mana_cost
+        self.card_name = card_name
+        self.attack = attack
+        self.life = life
+        self.stun_count = 0
+        self.can_act = True  # 行動（攻撃）可能か。必要？
+        self.attack_declaration = False  # 攻撃宣言済みか
+
+    def __str__(self):
+        return f"{self.card_name}"
+
+    def turn_start_effect(self):
+        """
+        ターン開始時効果
+        :return:
+        """
+        pass
+
+    def summon_effect(self):
+        """
+        召喚時効果
+        :return:
+        """
+        pass
+
+    def move_effect(self):
+        """
+        移動時効果
+        :return:
+        """
+        pass
+
+    def attack_effect(self):
+        """
+        攻撃時効果例：
+        電気クラゲ　スタン付与
+        隣のオコジョ 右前にも攻撃
+        :return:
+        """
+        pass
+
+    def legal_attack_targets(self) -> List:
+        """
+        取れる攻撃対象(敵の盤面いずれでも攻撃できるモンスターを実装するつもりがある)
+        隣のオコジョの場合は前と右前を攻撃できるが、このターゲットとしては前のみ。
+        攻撃時に両方攻撃するだけ。
+        :return:
+        """
+        if self.stun_count > 0:
+            return []
+        pass
+
+    def legal_moves(self) -> List:
+        """
+        左右移動が可能ならその分リストを返す
+        :return:
+        """
+        if self.stun_count > 0:
+            return []
+        pass

--- a/pythonProject/nullpoga_cui_2/gameutils/nullpoga_system.py
+++ b/pythonProject/nullpoga_cui_2/gameutils/nullpoga_system.py
@@ -1,0 +1,65 @@
+from enum import Enum
+from .spell_cards import SpellCard
+from .monster_cards import MonsterCard
+import types
+
+
+class CardType(Enum):
+    SPELL = "SPELL"
+    MONSTER = "MONSTER"
+
+
+def instance_card(card_no: int):
+    """0未採番だが0~99モンスターカード、100~199スペルカード"""
+    match card_no:
+        case 1:
+            return MonsterCard(card_no, 1, "ネズミ", 1, 1)
+        case 2:
+            card = MonsterCard(card_no, 2, "柴犬ランダル", 2, 1)
+
+            def custom_move_effect(self):
+                self.attack = self.attack + 1
+
+            card.move_effect = types.MethodType(custom_move_effect, card)
+            return card
+        case 3:
+            return MonsterCard(card_no, 2, "ネコ", 1, 2)
+        case 4:
+            card = MonsterCard(card_no, 2, "カエル三等兵", 0, 1)
+
+            def custom_turn_start_effect(self):
+                if not hasattr(self, "count"):
+                    self.count = 0
+                    self.life += 1
+                elif self.count == 1:
+                    self.attack += 1
+                elif self.count == 2:
+                    self.attack += 1
+                    self.life += 1
+                self.count += 1
+
+            card.turn_start_effect = types.MethodType(custom_turn_start_effect, card)
+            return card
+        case 5:
+            return MonsterCard(card_no, 2, "亀吉", 0, 4)
+        case 6:
+            card = MonsterCard(card_no, 2, "電気クラゲ", 1, 1)
+
+            def custom_attack_effect(self, opo_card: MonsterCard):
+                opo_card.stun_count += 1
+
+            card.attack_effect = types.MethodType(custom_attack_effect, card)
+            # メモ：スタンはどう実装するか?
+            # 盤面の情報から相手のモンスターカード自身にスタンのカウントを1増やす
+            # スタンのカウントが1以上のときはlegal_attack_targets,legal_movesが空配列になる
+            # スタンのカウントはターン終了時に1減らす
+            return card
+        case 7:
+            return MonsterCard(card_no, 3, "イノシシ", 3, 2)
+
+        case 100:
+
+            def cast_spell():
+                pass
+
+            return SpellCard(card_no, 1, "隕石落下", cast_spell)

--- a/pythonProject/nullpoga_cui_2/gameutils/spell_cards.py
+++ b/pythonProject/nullpoga_cui_2/gameutils/spell_cards.py
@@ -1,0 +1,33 @@
+import types
+from abc import ABC, abstractmethod
+from typing import List
+from gameutils.card_type import CardType
+import uuid
+from uuid import UUID
+from typing import Callable
+
+
+class SpellCard:
+    uniq_id: UUID
+    card_no: int
+    mana_cost: int
+    card_name: str
+    card_type: CardType
+
+    def __init__(self, card_no: int, mana_cost: int, card_name: str, cast_spell: Callable):
+        self.uniq_id = uuid.uuid4()
+        self.card_no = card_no
+        self.card_type = CardType.SPELL
+        self.mana_cost = mana_cost
+        self.card_name = card_name
+        self.cast_spell = cast_spell
+
+    def __str__(self):
+        return f"{self.card_name}"
+
+    def cast_spell(self):
+        """
+        スペル開始時効果
+        :return:
+        """
+        return self.cast_spell()

--- a/pythonProject/nullpoga_cui_2/istate.py
+++ b/pythonProject/nullpoga_cui_2/istate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class IState(ABC):
+    @abstractmethod
+    def legal_actions(self) -> List[int]:
+        pass
+
+    @abstractmethod
+    def random_action(self) -> int:
+        pass
+
+    @abstractmethod
+    def next(self, action: int) -> IState:
+        pass
+
+    @abstractmethod
+    def is_lose(self) -> bool:
+        pass
+
+    @abstractmethod
+    def is_draw(self) -> bool:
+        pass
+
+    @abstractmethod
+    def is_done(self) -> bool:
+        pass
+
+    @abstractmethod
+    def is_first_player(self) -> bool:
+        pass

--- a/pythonProject/nullpoga_cui_2/play_nullpoga_random.py
+++ b/pythonProject/nullpoga_cui_2/play_nullpoga_random.py
@@ -1,0 +1,35 @@
+from state import State
+import logging
+
+if __name__ == "__main__":
+    # 準備＆初期状態表示
+    state = State()
+    state.print()
+
+    # ゲーム開始（５枚ドロー）
+    # ログレベルをINFOにするとログは何も表示されない
+    # logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
+
+    # debug=False（もしくは指定しない）場合は終局まで一気に進む
+    # state.init_game(debug=False)
+    state.init_game(debug=True)
+    state.print()
+
+    # 10ターンプレイ
+    for _ in range(10):
+        # 先手プレイヤーでランダムなアクションの計画を設定
+        state.random_action()
+
+        # 後手プレイヤーでランダムなアクションの計画を設定
+        state = state.change_player()
+        state.random_action()
+        state = state.change_player()  # 別に手番は戻さなくてもよいが一応戻す
+
+        # １ターン分の処理を実行
+        state = state.next_turn()
+        state.print()
+
+        # ゲームが終了していたらbreak
+        if state.is_done():
+            break

--- a/pythonProject/nullpoga_cui_2/player.py
+++ b/pythonProject/nullpoga_cui_2/player.py
@@ -241,6 +241,9 @@ class Player:
         if target_slot.card is None:
             logging.debug("# 移動対象の列にモンスターカードが存在しない不発")
             return
+        if target_slot.card.done_activity:
+            logging.debug("# 移動対象のモンスターカードが行動済みのため不発")
+            return
 
         if action.action_data.move_direction == "left":
             assert idx > 0
@@ -248,6 +251,7 @@ class Player:
             if slot.card is not None:
                 logging.debug("# 移動先にモンスターカードが存在するため不発")
                 return
+            target_slot.card.done_activity = True
             self.zone.set_battle_field_card(idx - 1, target_slot.card)
 
         if action.action_data.move_direction == "right":
@@ -256,9 +260,11 @@ class Player:
             if slot.card is not None:
                 logging.debug("# 移動先にモンスターカードが存在するため不発")
                 return
+            target_slot.card.done_activity = True
             self.zone.set_battle_field_card(idx + 1, target_slot.card)
 
         self.zone.remove_battle_field_card(idx)
+
         logging.debug("# アクション完了")
 
     def do_monster_attack_declaration(self, action: Action):
@@ -271,11 +277,15 @@ class Player:
         assert action.action_type == ActionType.MONSTER_ATTACK
 
         idx = action.action_data.attack_declaration_idx
-        slot = self.zone.get_battle_field_slot(idx)
-        if slot.card is None:
+        target_slot = self.zone.get_battle_field_slot(idx)
+        if target_slot.card is None:
             logging.debug("# 攻撃宣言箇所にモンスターカードが存在しないため不発")
             return
-        slot.card.attack_declaration = True
+        if target_slot.card.done_activity:
+            logging.debug("# 攻撃宣言対象のモンスターカードが行動済みのため不発")
+            return
+        target_slot.card.done_activity = True
+        target_slot.card.attack_declaration = True
         logging.debug("# アクション完了")
 
     def move_forward(self):

--- a/pythonProject/nullpoga_cui_2/player.py
+++ b/pythonProject/nullpoga_cui_2/player.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+from typing import List, Optional, Union, Literal
+from enum import Enum
+from gameutils.monster_cards import MonsterCard
+from gameutils.spell_cards import SpellCard
+from gameutils.nullpoga_system import instance_card
+from dataclasses import dataclass, field
+import uuid
+from uuid import UUID
+import logging
+
+
+class Zone:
+    """バトルフィールド、スタンバイフィールドをまとめてZoneとする"""
+
+    def __init__(self):
+        # 自分から見ての5列の場をフィールドとして初期化
+        self.battle_field = [Slot() for _ in range(5)]
+        self.standby_field: List[Optional[MonsterCard]] = [None for _ in range(5)]
+
+    def set_battle_field_card(self, index: int, card: MonsterCard):
+        if 0 <= index < len(self.battle_field):
+            self.battle_field[index].set_card(card)
+
+    def set_standby_field_card(self, index: int, card: MonsterCard):
+        if 0 <= index < len(self.standby_field):
+            self.standby_field[index] = card
+
+    def get_battle_field_slot(self, index: int) -> Slot:
+        return self.battle_field[index]
+
+    def get_standby_field_card(self, index: int) -> MonsterCard | None:
+        return self.standby_field[index]
+
+    def remove_battle_field_card(self, index: int):
+        if 0 <= index < len(self.battle_field):
+            self.battle_field[index].remove_card()
+
+    def remove_standby_field_card(self, index: int):
+        if 0 <= index < len(self.standby_field):
+            self.standby_field[index] = None
+
+
+class FieldStatus(Enum):
+    NORMAL = "Normal"
+    WILDERNESS = "Wilderness"  # 荒野状態などの他の状態
+
+
+class Slot:
+    """バトルフィールドのそれぞれのマスをSlotとする"""
+
+    __slots__ = ["status", "card"]
+
+    def __init__(self):
+        self.status: FieldStatus = FieldStatus.NORMAL
+        self.card: Optional[MonsterCard] = None  # このフィールドに置かれているカード
+
+    def set_card(self, card: MonsterCard):
+        """Slotにモンスターカードを設定する"""
+        self.card = card
+
+    def remove_card(self):
+        """Slotのカードを除外する"""
+        self.card = None
+
+    def set_wild(self):
+        """Slotの状態を荒野状態にする"""
+        self.status = FieldStatus.WILDERNESS
+
+
+@dataclass
+class Action:
+    action_type: ActionType
+    action_data: Optional[ActionData] = None
+
+    def __str__(self):
+        if self.action_type == ActionType.SUMMON_MONSTER:
+            card_no = self.action_data.summon_card_no
+            idx = self.action_data.summon_standby_field_idx
+            return f"召喚アクション {card_no}を{idx}に召喚"
+        if self.action_type == ActionType.MONSTER_MOVE:
+            idx = self.action_data.move_battle_field_idx
+            direction = self.action_data.move_direction
+            return f"移動アクション 列{idx}のカードを{direction}に移動"
+        if self.action_type == ActionType.MONSTER_ATTACK:
+            idx = self.action_data.attack_declaration_idx
+            return f"攻撃宣言アクション 列{idx}のカードで攻撃"
+
+
+@dataclass
+class ActionData:
+    # SUMMON_MONSTER用
+    summon_card_no: Optional[int] = field(default=None)  # モンスターカードの番号
+    summon_standby_field_idx: Optional[int] = field(default=None)  # 左から何番目か
+    # MONSTER_MOVE用
+    move_battle_field_idx: Optional[int] = field(default=None)  # 左から何番目か
+    move_direction: Optional[Literal["right", "left"]] = field(default=None)  # 移動方向
+    # MONSTER_ATTACK用
+    attack_declaration_idx: Optional[int] = field(default=None)  # 攻撃宣言するバトルフィールドのインデックス
+    # 以下現状不使用
+    index: Optional[int] = field(default=None)
+    monster_card: Optional[MonsterCard] = field(default=None)
+    spell_card: Optional[SpellCard] = field(default=None)
+
+
+class PhaseKind(Enum):
+    # SPELL_PHASE = "SPELL_PHASE"  # スペルフェイズ。未実装
+    SUMMON_PHASE = "SUMMON_PHASE"  # 召喚行動フェイズ
+    ACTIVITY_PHASE = "ACTIVITY_PHASE"  # 攻撃フェイズ
+    END_PHASE = "END_PHASE"  # エンドフェイズ（というかターン終了の宣言）
+
+
+class ActionType(Enum):
+    # CAST_SPELL = "CAST_SPELL"  # スペル。未実装
+    SUMMON_MONSTER = "SUMMON_MONSTER"  # 召喚
+    MONSTER_MOVE = "MONSTER_MOVE"  # 移動
+    MONSTER_ATTACK = "MONSTER_ATTACK"  # 攻撃宣言
+    # SPELL_PHASE_END = "SPELL_PHASE_END" # スペルフェイズ終了宣言。未実装というか不要？
+    # SUMMON_PHASE_END = "SUMMON_PHASE_END"  # 召喚フェイズ終了宣言。未実装というか不要？
+    ACTIVITY_PHASE_END = "ACTIVITY_PHASE_END"  # ターン終了宣言に流用。
+
+
+class Player:
+    """プレイヤーオブジェクト？なぜPiece？
+    あくまで管理用でこれをAPIで動かすイメージ
+    """
+
+    summon_phase_actions: list[Action]
+
+    def __init__(self, deck_cards: List[int]):
+        self.turn_count = 0
+        self.player_id: UUID = uuid.uuid4()
+        # デッキの状態(シャッフルはしないので、シャッフルしてから渡す)
+        self.deck_cards: List[Union[MonsterCard, SpellCard]] = [instance_card(card_no) for card_no in deck_cards]
+        # 手札
+        self.hand_cards: List[Union[MonsterCard, SpellCard]] = []
+        # 場の札 memo:場の札。5レーンのため。
+        self.zone = Zone()
+        # フェイズも管理。（現在不使用）
+        # self.phase = PhaseKind.SPELL_PHASE
+        self.phase = PhaseKind.SUMMON_PHASE
+
+        self.mana = 0  # 相手のマナに干渉するカードを考えるためにplanと分けた
+        self.life = 15
+
+        self.spell_phase_actions: List[Action] = []
+        self.summon_phase_actions: List[Action] = []
+        self.activity_phase_actions: List[Action] = []
+
+        self.is_first_player: Optional[bool] = None
+
+    def legal_actions(self) -> List[Action]:
+        """現在の盤面を見て合法手（というか意味のある手）を列挙する"""
+        return self.legal_move_actions() + self.legal_summon_actions() + self.legal_attack_actions()
+
+    def legal_summon_actions(self) -> List[Action]:
+        """合法な（というか意味のある）モンスター召喚宣言アクション"""
+        actions = []
+        for card in self.hand_cards:
+            for standby_field_idx in range(5):
+                actions.append(
+                    Action(
+                        ActionType.SUMMON_MONSTER,
+                        action_data=ActionData(summon_card_no=card.card_no, summon_standby_field_idx=standby_field_idx),
+                    )
+                )
+        return actions
+
+    def legal_move_actions(self) -> List[Action]:
+        """合法な（というか意味のある）モンスター移動宣言アクション"""
+        actions = []
+        for battle_field_idx in range(5):
+            directions = []
+            if battle_field_idx != 0:
+                directions.append("left")
+            if battle_field_idx != 4:
+                directions.append("right")
+
+            for direction in directions:
+                actions.append(
+                    Action(
+                        ActionType.MONSTER_MOVE,
+                        action_data=ActionData(move_battle_field_idx=battle_field_idx, move_direction=direction),
+                    )
+                )
+        return actions
+
+    def legal_attack_actions(self) -> List[Action]:
+        """合法な（というか意味のある）モンスター攻撃宣言アクション"""
+        actions = []
+        for battle_field_idx in range(5):
+            actions.append(
+                Action(
+                    ActionType.MONSTER_ATTACK,
+                    action_data=ActionData(attack_declaration_idx=battle_field_idx),
+                )
+            )
+        return actions
+
+    def do_summon_monster(self, action: Action):
+        """モンスターを召喚する
+        - プレイヤーの宣言順に処理（意味ない）
+        - 召喚先のスタンバイゾーンにモンスターカードがある場合は不発（スペルでそうなった場合など）
+        - 手札にモンスターカードがない場合は不発（スペルで除外された場合など）
+        - マナが足りない場合は不発
+        """
+        assert action.action_type == ActionType.SUMMON_MONSTER
+
+        # 手札から召喚対象のカード１枚を見つける
+        target_card = next((card for card in self.hand_cards if card.card_no == action.action_data.summon_card_no), None)
+        if target_card is None:
+            logging.debug("# 召喚対象のモンスターが手札に存在しないため不発")
+            return
+
+        if self.zone.get_standby_field_card(action.action_data.summon_standby_field_idx) is not None:
+            logging.debug("# 召喚のスタンバイフィールドにモンスターが存在するため不発")
+            return
+
+        if self.mana < target_card.mana_cost:
+            logging.debug("# マナが足りないため不発")
+            return
+
+        self.zone.standby_field[action.action_data.summon_standby_field_idx] = target_card
+        new_hand_cards = [card for card in self.hand_cards if card != target_card]
+        self.hand_cards = new_hand_cards
+        self.mana -= target_card.mana_cost
+        logging.debug("# アクション完了")
+
+    def do_move_monster(self, action: Action):
+        """移動処理を行う。
+        - プレイヤーの宣言順に処理（スペルも考慮すると意味あり。戦略的に同じ箇所に移動宣言するのもあり）
+        - 移動対象のカードが存在しなければ不発
+        - 本当に移動できるかは確定していないので、移動できない場合もある
+          - 先に破壊される可能や移動先にモンスターが存在する場合など
+        - 逆に宣言時に移動先が埋まっていても、移動処理時に空いていれば移動可能
+        """
+        assert action.action_type == ActionType.MONSTER_MOVE
+
+        idx = action.action_data.move_battle_field_idx
+        target_slot = self.zone.get_battle_field_slot(idx)
+        if target_slot.card is None:
+            logging.debug("# 移動対象の列にモンスターカードが存在しない不発")
+            return
+
+        if action.action_data.move_direction == "left":
+            assert idx > 0
+            slot = self.zone.get_battle_field_slot(idx - 1)
+            if slot.card is not None:
+                logging.debug("# 移動先にモンスターカードが存在するため不発")
+                return
+            self.zone.set_battle_field_card(idx - 1, target_slot.card)
+
+        if action.action_data.move_direction == "right":
+            assert idx < 4
+            slot = self.zone.get_battle_field_slot(idx + 1)
+            if slot.card is not None:
+                logging.debug("# 移動先にモンスターカードが存在するため不発")
+                return
+            self.zone.set_battle_field_card(idx + 1, target_slot.card)
+
+        self.zone.remove_battle_field_card(idx)
+        logging.debug("# アクション完了")
+
+    def do_monster_attack_declaration(self, action: Action):
+        """攻撃宣言をする
+        - プレイヤーの宣言順に処理（意味ない）
+        - この後にモンスターが破壊される可能性もあり、攻撃できるかは確定していない
+        - 宣言した場所にモンスターカードがない場合は不発（スペルで除外された場合など）
+        """
+        # NOTE: そのターンに移動済みのモンスターは攻撃できない？（カードにフラグもたせる？）
+        assert action.action_type == ActionType.MONSTER_ATTACK
+
+        idx = action.action_data.attack_declaration_idx
+        slot = self.zone.get_battle_field_slot(idx)
+        if slot.card is None:
+            logging.debug("# 攻撃宣言箇所にモンスターカードが存在しないため不発")
+            return
+        slot.card.attack_declaration = True
+        logging.debug("# アクション完了")
+
+    def move_forward(self):
+        """Zoneのモンスターカードを全て進軍させる（強制）"""
+        for i, standby_card in enumerate(self.zone.standby_field):
+            if standby_card and not self.zone.battle_field[i].card:
+                standby_card.can_act = False
+                self.zone.battle_field[i].card = standby_card
+                self.zone.standby_field[i] = None
+
+    def draw_card(self):
+        """デッキから１枚引く"""
+        card = self.deck_cards.pop()
+        self.hand_cards.append(card)

--- a/pythonProject/nullpoga_cui_2/readme.md
+++ b/pythonProject/nullpoga_cui_2/readme.md
@@ -1,0 +1,7 @@
+# nullpoga実装
+
+## Usage
+```
+cd nullpoga_TCG-main\pythonProjecnullpoga_cui\
+python play_nullpoga_random.py
+```

--- a/pythonProject/nullpoga_cui_2/state.py
+++ b/pythonProject/nullpoga_cui_2/state.py
@@ -251,13 +251,13 @@ class State(IState):
 
         # 各種勝敗判定
         # 先手のプレイヤーが勝ち
-        if new_state.second_player().life <= 0:
+        if new_state.second_player().life <= 0 and new_state.second_player().life < new_state.first_player().life:
             new_state = State(player_1, player_2)
             new_state.game_finished = True
             new_state.first_player_win = True
             return new_state
         # 後手のプレイヤーが勝ち
-        if new_state.first_player().life <= 0:
+        if new_state.first_player().life <= 0 and new_state.first_player().life < new_state.second_player().life:
             new_state = State(player_1, player_2)
             new_state.game_finished = True
             new_state.second_player_win = True

--- a/pythonProject/nullpoga_cui_2/state.py
+++ b/pythonProject/nullpoga_cui_2/state.py
@@ -173,7 +173,13 @@ class State(IState):
                 break
 
         # ターン終了
-        # TODO: 移動済みモンスターが攻撃できないようにする場合はここで移動済みフラグをリセットする
+        # 移動済みモンスターが攻撃できないようにする場合はここで行動済みフラグをリセットする
+        for idx, slot in enumerate(player_1.zone.battle_field):
+            if slot.card is not None and slot.card.attack_declaration:
+                slot.card.done_activity = False
+        for idx, slot in enumerate(player_2.zone.battle_field):
+            if slot.card is not None:
+                slot.card.done_activity = False
 
         # デッキ切れ判定（とりあえず引き分け）
         if len(temp_state.player_1.deck_cards) == 0 or len(temp_state.player_2.deck_cards) == 0:

--- a/pythonProject/nullpoga_cui_2/state.py
+++ b/pythonProject/nullpoga_cui_2/state.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+import hashlib
+import json
+import random
+
+from istate import IState
+from typing import List, Optional, Final
+import copy
+from gameutils.monster_cards import MonsterCard
+from gameutils.spell_cards import SpellCard
+from player import Player, Action, ActionData, ActionType, Slot, FieldStatus
+
+import logging
+
+DECK_1: Final = [7, 5, 2, 1, 4, 6, 7, 5, 1, 4, 3, 3, 6, 2]
+DECK_2: Final = [4, 1, 7, 5, 5, 7, 6, 3, 4, 1, 3, 6, 2, 2]
+
+
+# デバッグ用
+# Trueにすると攻撃処理とnext処理のたびに停止してキー入力を受け付ける
+DEBUG = False
+
+
+def get_view(target: Slot | int | MonsterCard | SpellCard | None):
+    """CLI表示の見た目調整用"""
+    L = 15
+    if target is None:
+        return " " * L
+    if type(target) == Slot:
+        if target.card is None:
+            if target.status == FieldStatus.WILDERNESS:
+                return "x" * L
+            else:
+                return " " * L
+        else:
+            card = target.card
+            attack_declaration = "ad" if card.attack_declaration else "--"
+            status = f"{attack_declaration}"
+            if target.status == FieldStatus.WILDERNESS:
+                return f"xx {card.card_no:02}({str(card.life):>2},{status}) xx"
+            else:
+                return f"   {card.card_no:02}({str(card.life):>2},{status})   "
+    if type(target) == MonsterCard or SpellCard:
+        card = target
+        attack_declaration = "ad" if card.attack_declaration else "--"
+        status = f"{attack_declaration}"
+        status = f"{attack_declaration}"
+        return f"   {card.card_no:02}({str(card.life):>2},{status})   "
+    if type(target) == int:
+        return f"{target:02}"
+
+
+class State(IState):
+    """ゲームの状態を管理する。本質的な情報はPlayerが持つ。"""
+
+    def __init__(self, player_1: Optional[Player] = None, player_2: Optional[Player] = None):
+        # player_1を「手番のプレイヤー」と呼ぶ
+        self.player_1: Player = player_1 if player_1 is not None else Player(DECK_1)
+        self.player_2: Player = player_2 if player_2 is not None else Player(DECK_2)
+
+        # ゲーム終了判定フラグ
+        self.game_finished = False
+        self.first_player_win = False
+        self.second_player_win = False
+
+    def init_game(self, debug=False):
+        """初期状態からゲームを始める"""
+        # デバッグ用
+        global DEBUG
+        DEBUG = debug
+
+        # 便宜上「先手プレイヤー」のフラグを付けておく
+        # 「先手プレイヤー」はplayer_1にもplayer_2にもなるので注意
+        # というか手番が変わっても先手プレイヤーが判断できるようにフラグつけている
+        self.player_1.is_first_player = True
+        self.player_2.is_first_player = False
+
+        # デッキをシャッフル
+        random.shuffle(self.player_1.deck_cards)
+        random.shuffle(self.player_2.deck_cards)
+
+        # ５枚ドロー
+        for _ in range(5):
+            self.player_1.draw_card()
+            self.player_2.draw_card()
+
+        # 初期マナを付与（デッキ枚数とゲームスピードの調整のため少し多めにしている）
+        self.player_1.mana += 10
+        self.player_2.mana += 10
+
+    def to_json(self):
+        """お試し。ゲーム情報のインポート、エクスポート用"""
+        state_json = {
+            "palyer1": {
+                "life": self.player_1.life,
+                "phase": str(self.player_1.phase),
+                "hands": [card.card_no for card in self.player_1.hand_cards],
+                "deck": [card.card_no for card in self.player_1.deck_cards],
+                "zone": {
+                    "battle_field": [get_view(slot) for slot in self.player_1.zone.battle_field],
+                    "standby": [get_view(card) if card is not None else None for card in self.player_1.zone.standby_field],
+                },
+            },
+            "palyer2": {
+                "life": self.player_2.life,
+                "phase": str(self.player_2.phase),
+                "hands": [get_view(card) for card in self.player_2.hand_cards],
+                "deck": [get_view(card) for card in self.player_2.deck_cards],
+                "zone": {
+                    "battle_field": [get_view(slot) for slot in self.player_2.zone.battle_field],
+                    "standby": [get_view(card) if card is not None else None for card in self.player_2.zone.standby_field],
+                },
+            },
+        }
+        return state_json
+
+    def __hash__(self) -> int:
+        """お試し。盤面管理の効率化のためにハッシュ化できるようにしておく"""
+        return hashlib.md5(json.dumps(self.to_json(), sort_keys=True)).hexdigest()
+
+    def __eq__(self, other: State):
+        """お試し。等価判定。ハッシュが衝突したとき用だけどほぼ無意味"""
+        return json.dumps(self.to_json(), sort_keys=True) == json.dumps(other.to_json(), sort_keys=True)
+
+    def next_turn(self) -> State:
+        """各プレイヤーの入力が終わっている前提で、１ターン文の処理を行う。
+        お互いのプレイヤーの予約されたアクションを処理する"""
+        # すでにゲームが終了している場合はエラー
+        if self.game_finished:
+            raise Exception("# すでにゲームが終了しています。")
+        # 一旦nextで実装だが、まとめてもよさそう
+        player_1 = copy.deepcopy(self.player_1)
+        player_2 = copy.deepcopy(self.player_2)
+        temp_state = State(player_1, player_2)
+        # ★スペルフェイズを処理
+        # スペル処理（プレイヤー入力）
+        for action in player_1.spell_phase_actions:
+            temp_state = temp_state.next(action)
+        temp_state = temp_state.change_player()
+        for action in player_2.spell_phase_actions:
+            temp_state = temp_state.next(action)
+        temp_state = temp_state.change_player()
+
+        # ★召喚フェイズを処理
+        # 進軍処理（自動）
+        temp_state.player_1.move_forward()
+        temp_state.player_2.move_forward()
+        # 召喚処理（プレイヤー入力）
+        for action in player_1.summon_phase_actions:
+            temp_state = temp_state.next(action)
+        temp_state = temp_state.change_player()
+        for action in player_2.summon_phase_actions:
+            temp_state = temp_state.next(action)
+        temp_state = temp_state.change_player()
+
+        # ★行動フェイズを処理
+        # 行動、攻撃宣言処理（プレイヤー入力）
+        # メモ：攻撃宣言はインデックスで宣言。個劇処理時に宣言箇所にカードがなければ不発（スキップ）
+        for action in player_1.activity_phase_actions:
+            temp_state = temp_state.next(action)
+        temp_state = temp_state.change_player()
+        for action in player_2.activity_phase_actions:
+            temp_state = temp_state.next(action)
+        temp_state = temp_state.change_player()
+        # 攻撃処理（自動）
+        for i in range(5):
+            temp_state = temp_state.resolve_attack_phase_1step()
+            if DEBUG:
+                input(f"攻撃処理 [{i}/5]step")
+                temp_state.print()
+                input("デバッグモード・・・適当なキーを押してください")
+            if temp_state.game_finished:
+                break
+
+        # ターン終了
+        # TODO: 移動済みモンスターが攻撃できないようにする場合はここで移動済みフラグをリセットする
+
+        # デッキ切れ判定（とりあえず引き分け）
+        if len(temp_state.player_1.deck_cards) == 0 or len(temp_state.player_2.deck_cards) == 0:
+            temp_state.game_finished = True
+            logging.debug("# デッキ切れのためゲーム終了です")
+            return temp_state
+
+        if temp_state.game_finished:
+            logging.debug("# ゲーム終了です")
+
+        # 次のターン開始して再度プレイヤーの入力を受け付ける
+        temp_state.player_1.draw_card()
+        temp_state.player_2.draw_card()
+        temp_state.player_1.mana += 1
+        temp_state.player_2.mana += 1
+
+        return temp_state
+
+    def resolve_attack_phase_1step(self) -> State:
+        """1回分の攻撃処理。新しいゲームの状態を返す"""
+        player_1 = copy.deepcopy(self.player_1)
+        player_2 = copy.deepcopy(self.player_2)
+        new_state = State(player_1, player_2)
+
+        def attack(player: Player, enemy_player: Player, battle_field_idx: int):
+            # 攻撃対象のモンスターがいない場合はなにもしない
+            if battle_field_idx is None:
+                return
+            card = player.zone.battle_field[battle_field_idx].card
+            # 攻撃対象にカードがない場合
+            target_slot = enemy_player.zone.battle_field[4 - battle_field_idx]
+            if target_slot.card is None and target_slot.status == FieldStatus.WILDERNESS:
+                logging.debug(f"# 直接攻撃（荒野済み）-> {card.attack}ダメージ")
+                enemy_player.life -= card.attack
+            elif target_slot.card is None:
+                logging.debug(f"# 直接攻撃＆荒野化-> {card.attack}ダメージ")
+                enemy_player.life -= card.attack
+                target_slot.set_wild()
+            elif target_slot.status == FieldStatus.WILDERNESS:
+                logging.debug(f"# カードに攻撃（荒野済み）-> {card.attack}ダメージ")
+                target_slot.card.life -= card.attack
+            else:
+                logging.debug(f"# カードに攻撃-> {card.attack}ダメージ")
+                target_slot.card.life -= card.attack
+            card.attack_declaration = False
+
+        # 攻撃可能モンスターの判定
+        player_1_idx = None
+        player_2_idx = None
+        for idx, slot in enumerate(player_1.zone.battle_field):
+            if slot.card is not None and slot.card.attack_declaration:
+                player_1_idx = idx
+                break
+        for idx, slot in enumerate(player_2.zone.battle_field):
+            if slot.card is not None and slot.card.attack_declaration:
+                player_2_idx = idx
+                break
+
+        attack(player_1, player_2, player_1_idx)
+        attack(player_2, player_1, player_2_idx)
+
+        # モンスターカードの破壊処理
+        for idx, slot in enumerate(player_1.zone.battle_field):
+            if slot.card is not None and slot.card.life <= 0:
+                slot.remove_card()
+        for idx, slot in enumerate(player_2.zone.battle_field):
+            if slot.card is not None and slot.card.life <= 0:
+                slot.remove_card()
+
+        # 各種勝敗判定
+        # 先手のプレイヤーが勝ち
+        if new_state.second_player().life <= 0:
+            new_state = State(player_1, player_2)
+            new_state.game_finished = True
+            new_state.first_player_win = True
+            return new_state
+        # 後手のプレイヤーが勝ち
+        if new_state.first_player().life <= 0:
+            new_state = State(player_1, player_2)
+            new_state.game_finished = True
+            new_state.second_player_win = True
+            return new_state
+        # 引き分け
+        if new_state.first_player().life <= 0 and new_state.second_player().life <= 0:
+            new_state = State(player_1, player_2)
+            new_state.game_finished = True
+            if new_state.first_player().life > new_state.second_player().life:
+                new_state.first_player_win = True
+            elif new_state.second_player().life > new_state.second_player().life:
+                new_state.second_player_win = True
+            return new_state
+
+        # 先手フィールドの荒野判定
+        first_player_wilderness_all = True
+        for idx, slot in enumerate(new_state.first_player().zone.battle_field):
+            if slot.status != FieldStatus.WILDERNESS:
+                first_player_wilderness_all = False
+
+        # 後手フィールドの荒野判定
+        second_player_wilderness_all = True
+        for idx, slot in enumerate(new_state.second_player().zone.battle_field):
+            if slot.status != FieldStatus.WILDERNESS:
+                second_player_wilderness_all = False
+
+        # 先手勝ちの場合
+        if not first_player_wilderness_all and second_player_wilderness_all:
+            new_state.game_finished = True
+            new_state.first_player_win = True
+            return new_state
+        if first_player_wilderness_all and not second_player_wilderness_all:
+            new_state.game_finished = True
+            new_state.second_player_win = True
+            return new_state
+        if first_player_wilderness_all and second_player_wilderness_all:
+            # 両方荒野の場合はライフで判断
+            new_state.game_finished = True
+            if new_state.first_player().life > new_state.second_player().life:
+                new_state.first_player_win = True
+            elif new_state.second_player().life > new_state.second_player().life:
+                new_state.second_player_win = True
+            return new_state
+
+        return State(player_1, player_2)
+
+    def change_player(self) -> State:
+        """手番を変更して新しい状態を返す"""
+        player_1 = copy.deepcopy(self.player_1)
+        player_2 = copy.deepcopy(self.player_2)
+        return State(player_2, player_1)
+
+    def next(self, action: Action) -> State:
+        """アクションを受け付け、状態を更新して次の状態を返す。
+        めっちゃ細かい。実質デバッグ用。
+
+        Parameters
+        ----------
+        action : Action
+            アクション
+
+        Returns
+        -------
+        State
+            新しいゲームの状態
+        """
+        # 古い状態を辺にいじらないようにコピーする
+        player_1 = copy.deepcopy(self.player_1)
+        player_2 = copy.deepcopy(self.player_2)
+
+        if action.action_type == ActionType.SUMMON_MONSTER:
+            logging.debug(f"ActionType.SUMMON_MONSTER {str(action)}")
+            player_1.do_summon_monster(action)
+        if action.action_type == ActionType.MONSTER_MOVE:
+            logging.debug(f"ActionType.MONSTER_MOVE {str(action)}")
+            player_1.do_move_monster(action)
+        if action.action_type == ActionType.MONSTER_ATTACK:
+            logging.debug(f"ActionType.MONSTER_ATTACK {str(action)}")
+            player_1.do_monster_attack_declaration(action)
+
+        new_state = State(player_1, player_2)
+        if DEBUG:
+            new_state.print()
+            input("デバッグモード・・・適当なキーを押してください")
+        return new_state
+
+    def legal_actions(self) -> List[int]:
+        """手番のプレイヤーの現在の状態での合法手を列挙する。
+
+        Returns
+        -------
+        List[int]
+            合法手のリスト
+        """
+        return self.player_1.legal_actions()
+
+    def random_action(self) -> None:
+        """手番のプレイヤーのアクションを設定する"""
+        summon_actions = self.player_1.legal_summon_actions()
+        random.shuffle(summon_actions)
+        self.player_1.summon_phase_actions = summon_actions
+
+        move_actions = self.player_1.legal_move_actions()
+        attack_actions = self.player_1.legal_attack_actions()
+        activity_actions = move_actions + attack_actions
+        random.shuffle(activity_actions)
+        self.player_1.activity_phase_actions = activity_actions
+
+    def is_lose_first_player(self) -> bool:
+        """先手が負けているかを判定"""
+        return self.game_finished and self.second_player_win
+
+    def is_lose_second_player(self) -> bool:
+        """後手が負けているかを判定"""
+        return self.game_finished and self.first_player_win
+
+    def is_draw(self) -> bool:
+        """引き分けを判定"""
+        return self.game_finished and not self.first_player_win and not self.second_player_win
+
+    def is_done(self) -> bool:
+        """ゲーム終了条件を判定"""
+        return self.game_finished
+
+    def first_player(self) -> Player:
+        return self.player_1 if self.player_1.is_first_player else self.player_2
+
+    def second_player(self) -> Player:
+        return self.player_2 if self.player_1.is_first_player else self.player_1
+
+    def is_first_player(self) -> bool:
+        """現在の手番が先手番の場合True"""
+        return self.player_1.is_first_player
+
+    def is_lose(self) -> bool:
+        return self.is_lose_first_player()
+
+    def __str__(self) -> str:
+        """コンソールでの確認用"""
+        L = 110
+        s = "=" * L + "\n"
+        s += "player2_mana    : " + f"{self.player_2.mana:>3}" + "\n"
+        s += "player2_life    : " + f"{self.player_2.life:>3} ({self.player_2.phase})" + "\n"
+        s += "player2_hand    : " + ",".join(f"[{get_view(card)}]" for card in self.player_2.hand_cards[::-1]) + "\n"
+        s += "-" * L + "\n"
+        s += "player2_standby : " + ",".join(f"[{get_view(card)}]" for card in self.player_2.zone.standby_field[::-1]) + "\n"
+        s += "-" * L + "\n"
+        s += "player2_battle  : " + ",".join(f"[{get_view(card)}]" for card in self.player_2.zone.battle_field[::-1]) + "\n"
+        s += "=" * L + "\n"
+        s += "player1_battle  : " + ",".join(f"[{get_view(card)}]" for card in self.player_1.zone.battle_field) + "\n"
+        s += "-" * L + "\n"
+        s += "player1_standby : " + ",".join(f"[{get_view(card)}]" for card in self.player_1.zone.standby_field) + "\n"
+        s += "-" * L + "\n"
+        s += "player1_hand    : " + ",".join(f"[{get_view(card)}]" for card in self.player_1.hand_cards) + "\n"
+        s += "player1_life    : " + f"{self.player_1.life:>3} ({self.player_1.phase})" + "\n"
+        s += "player1_mana    : " + f"{self.player_1.mana:>3}" + "\n"
+        s += "=" * L + "\n"
+        if self.is_first_player():
+            s += f"(先手番視点)\n"
+        else:
+            s += f"(後手番視点)\n"
+        return s
+
+    def print(self):
+        print(str(self))
+
+
+if __name__ == "__main__":
+    # デバッグ用
+
+    # 準備
+    state = State()
+    state.print()
+
+    # ゲーム開始（５枚ドロー）
+    state.init_game()
+    state.print()
+
+    for _ in range(10):
+        state.random_action()
+        state = state.change_player()
+        state.random_action()
+        state = state.change_player()
+        state = state.next_turn()
+        state.print()
+
+        if state.is_done():
+            break
+
+    # デバッグ用
+    if False:
+        # デバッグ用手動実行
+        # 召喚（先手プレイヤー）
+        action = Action(ActionType.SUMMON_MONSTER, action_data=ActionData(summon_card_no=2, summon_standby_field_idx=4))
+        state = state.next(action)
+        state.print()
+
+        # 召喚（先手プレイヤー）
+        action = Action(ActionType.SUMMON_MONSTER, action_data=ActionData(summon_card_no=6, summon_standby_field_idx=1))
+        state = state.next(action)
+        state.print()
+
+        # 先手プレイヤーのターンを終了する
+        action = Action(ActionType.ACTIVITY_PHASE_END, action_data=ActionData())
+        state = state.next(action)
+        state = state.change_player()  # ここでプレイヤーが入れ替わるのに注意
+        state.print()
+
+        # 後手プレイヤーは何もしないでターンを終了
+        action = Action(ActionType.ACTIVITY_PHASE_END, action_data=ActionData())
+        state = state.next(action)
+        state = state.change_player()  # ここでプレイヤーが入れ替わるのに注意
+        state.print()
+
+        # 進軍フェーズ（強制）
+        state.player_1.move_forward()
+        state.player_2.move_forward()
+        state.print()
+
+        # 行動フェーズ（移動アクションの処理）
+        action = Action(
+            ActionType.MONSTER_MOVE,
+            action_data=ActionData(
+                move_battle_field_idx=4,
+                move_direction="left",
+            ),
+        )
+        state = state.next(action)
+        state.print()
+
+        # 行動フェーズ（攻撃宣言の処理）
+        action = Action(
+            ActionType.MONSTER_ATTACK,
+            action_data=ActionData(attack_declaration_idx=1),
+        )
+        state = state.next(action)
+        state.print()
+
+        # 本当は５回やる
+        state = state.resolve_attack_phase_1step()
+        state.print()


### PR DESCRIPTION
## nullpoga_cuiとの差分

- `NullPoGaPiece`は`Player`オブジェクトとしファイルを分離した。
- `State`は`Player`を通じて基本的なアクションを処理する。攻撃処理や勝敗判定など`Player`のアクションの範囲外の箇所は`State`で処理する
- アクションは基本的になんでも許して、実行できない場合は実行時に不発になるようにしている。
  - その方がスペルを追加したときとの相性が良いと思う
  - ただ人間が操作した場合の操作性は微妙かもしれない
- アクションは`Player`内の`spell_phase_actions`, `summon_phase_actions`, `activity_phase_actions`にリストで保持して、実行時はリストの順に実行している。
- 一部の`ActionType`は考慮しないで実装。
- Playerの`SPELL_PHASE`などのフェイズ管理は一旦考慮しないで実装。